### PR TITLE
fix #33

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,16 @@ demos that are for the Beagle you are running.
 Demo                                 | Description
 ----                                 | -----------
 autorun                              | Place files in here that you want to run whenever the Beagle starts.
-[BeagleBone](BeagleBone/README.md)             | Here you'll find demos for all of the BeagleBones.  The PocketBeagle demos are in another folder.
+[BeagleBone](BeagleBone/README.md)   | Here you'll find demos for all of the BeagleBones.  The PocketBeagle demos are in another folder.
 [BeagleBone/AI](BeagleBone/AI)       | Demos for the BeagleBone AI.
 [BeagleBone/Black](BeagleBone/Black) | Demos for the Black and Green families of Bones.  This includes the wirelss versions too.
 [BeagleBone/Blue](BeagleBone/Blue)   | Demos that run on the EduMIP balancing robot.
 [BeagleBone/Green](BeagleBone/Green) | Additional demos that run on the Grove system on the Green.
 common                               | PRU files that are common to all the Beagles.
+[displays](displays/README.md)       | Examples for interfacing displays.
 [extras](extras)                     | Lots of other demos.
 [PocketBeagle](PocketBeagle)         | Demos for the smallest of Beagles.
-[sensorExamples](sensorExamples/README.md)     | Examples for interfacing various sensors.  Works on all Beagles
+[sensors](sensors/README.md)         | Examples for interfacing various sensors.  Works on all Beagles
 
 # Status on different branches
 


### PR DESCRIPTION
> In the cloud9-examples README it references a "sensorExamples" folder that does not exist on the system or in github. I believe this should be just 'sensors'

fixed this issue and added display listing in the table.