### PR TITLE
Remove bonescript from PocketBeagle fadeLED.js example

### DIFF
--- a/PocketBeagle/TechLab/fadeLED.js
+++ b/PocketBeagle/TechLab/fadeLED.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-var b = require('bonescript');
+var fs = require('fs');
 var LED = '/sys/class/leds/techlab::blue/brightness';
 var step = 10,      // Step size
     min = 0,        // dimmest value
@@ -17,7 +17,7 @@ function doInterval(err, x) {
 }
 
 function fade() {
-    b.writeTextFile(LED, brightness);
+    fs.writeFileSync(LED, brightness);
     brightness += step;
     if(brightness >= max || brightness <= min) {
         step = -1 * step;


### PR DESCRIPTION
Update fadeLED.js example for PocketBeagle, removing use of bonescript (see Issue #38). Have not had a chance to test the code on a PocketBeagle (do not have access to hardware).